### PR TITLE
[GUARD] Change default port to work with GUARD helm charts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,4 @@ YAML_FILEPATH=.gateway-endpoints.yaml                                           
 # POSTGRES_CONNECTION_STRING=postgres://postgres:password@localhost:5432/postgres?sslmode=disable # The connection string for the Postgres database.
 
 # Optional:
-PORT=8080                                                                                         # The port to listen on for incoming HTTP requests. (Defaults to 50051)
+PORT=8080                                                                                         # The port to listen on for incoming HTTP requests. (Defaults to 10002)

--- a/env.go
+++ b/env.go
@@ -12,7 +12,7 @@ const (
 	yamlFilePathEnv             = "YAML_FILEPATH"
 
 	portEnv     = "PORT"
-	defaultPort = "50051"
+	defaultPort = "10002"
 )
 
 type envVars struct {


### PR DESCRIPTION
## 🌿 Summary

Update default port configuration to align with GUARD helm charts.

### 🌱 Primary Changes:
- Changed default port from `50051` to `10002` in `.env.example` and `env.go` to ensure compatibility with GUARD helm charts.

### 🍃 Secondary changes:
- Updated comments in `.env.example` to reflect the new default port value.

## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
